### PR TITLE
ENH: Allow plotting base mitochondrial plots

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -94,3 +94,8 @@ History
 
 * Implement interactive basic linear plots;
 * Implement interactive split linear plots.
+
+0.8.0 (2020-04-05)
+==================
+
+* Add ``mitoviz-base`` command to create base mitochondrial plots.

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,10 @@ separator is used (as in the case of TSV files), just specify it with the ``--se
 
     $ mitoviz sample.tsv --sep "\t"
 
+If you just need to create an empty mitochondrial plot, we've got you covered: use the
+``mitoviz-base`` command and provide one or more options like ``--linear``, ``--interactive``,
+``--legend``, ``--split``, ``--output``, based on your needs.
+
 Python Module
 -------------
 
@@ -164,6 +168,10 @@ when processing the given input file:
 .. code-block:: python
 
     plot_table("sample.tsv", sep="\t", comment="#", skiprows=0)
+
+If you just need to create an empty mitochondrial plot, the ``plot_base`` function allows to do so,
+and accepts the ``linear``, ``interactive``, ``legend``, ``split``, ``output`` and ``save``
+arguments to further tweak its behaviour.
 
 Please refer to the Usage_ section of the documentation for further information.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,8 +84,24 @@ Additional keyword options can be specified in the format ``option=value``, and 
 
     $ mitoviz sample.tsv --sep "\t" comment=#
 
+If you just need to create an empty mitochondrial plot, we've got you covered: use the
+``mitoviz-base`` command and provide one or more options like ``--linear``, ``--interactive``,
+``--legend``, ``--split``, ``--output``, based on your needs:
 
-Comprehensive help about the mitoviz CLI can be found with ``mitoviz --help``.
+.. code-block:: console
+
+    # Create a base polar plot
+    $ mitoviz-base
+
+    # Create a base linear plot and save it as "base_linear.png"
+    $ mitoviz-base --linear --output "base_linear.png"
+
+    # Create an interactive linear plot with split loci
+    $ mitoviz-base --linear --interactive --split
+
+
+Comprehensive help about the mitoviz CLI can be found with ``mitoviz --help`` and
+``mitoviz-base --help``.
 
 Python Module
 -------------
@@ -216,3 +232,18 @@ when processing the given input file:
 
 
 Comprehensive help about the ``plot_table`` function can be found with ``help(mitoviz.plot_table)``.
+
+If you just need to create an empty mitochondrial plot, the ``plot_base`` function allows to do so,
+and accepts the ``linear``, ``interactive``, ``legend``, ``split``, ``output`` and ``save``
+arguments to further tweak its behaviour:
+
+.. code-block:: python
+
+    from mitoviz import plot_base
+
+    # Create a base polar plot
+    plot_base()
+    # Create a base linear plot and save it as "base_linear.png"
+    plot_base(linear=True, save=True, output="base_linear.png)
+    # Create an interactive linear plot with split loci
+    plot_base(linear=True, interactive=True, split=True)

--- a/mitoviz/__init__.py
+++ b/mitoviz/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 # Created by Roberto Preste
-from mitoviz.mitoviz import plot_df, plot_table, plot_vcf  # noqa
+from mitoviz.mitoviz import plot_base, plot_df, plot_table, plot_vcf  # noqa
 
 __author__ = """Roberto Preste"""
 __email__ = "robertopreste@gmail.com"

--- a/mitoviz/cli/__init__.py
+++ b/mitoviz/cli/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Created by Roberto Preste

--- a/mitoviz/cli/mitoviz_base.py
+++ b/mitoviz/cli/mitoviz_base.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Created by Roberto Preste
+import sys
+
+import click
+
+from mitoviz.mitoviz import plot_base
+
+
+@click.command("mitoviz-base")
+@click.version_option()
+@click.option("--linear", "-r", default=False, is_flag=True,
+              help="Show a linear plot rather than a polar one.")
+@click.option("--output", "-o", default=None, help="Output filename.")
+@click.option("--legend", "-L", default=False, is_flag=True,
+              help="Add legend to the plot.")
+@click.option("--split", "-p", default=False, is_flag=True,
+              help="Plot split H and L strands.")
+@click.option("--interactive", "-i", default=False, is_flag=True,
+              help="Create an interactive version of the plot.")
+def main(linear, output, legend, split, interactive):
+    """ Plot an empty base mitochondrial representation. """
+    plot_base(linear=linear, save=True, output=output, legend=legend,
+              split=split, interactive=interactive)
+
+
+if __name__ == "__main__":
+    sys.exit(main())  # pragma: no cover

--- a/mitoviz/cli/mitoviz_plot.py
+++ b/mitoviz/cli/mitoviz_plot.py
@@ -9,8 +9,8 @@ import click
 from mitoviz.mitoviz import plot_table, plot_vcf
 
 
-@click.command(context_settings=dict(ignore_unknown_options=True,
-                                     allow_extra_args=True))
+@click.command("mitoviz", context_settings=dict(ignore_unknown_options=True,
+                                                allow_extra_args=True))
 @click.version_option()
 @click.argument("input_file", type=click.Path(exists=True))
 @click.option("--linear", "-r", default=False, is_flag=True,

--- a/mitoviz/cli/tests/__init__.py
+++ b/mitoviz/cli/tests/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Created by Roberto Preste

--- a/mitoviz/cli/tests/test_mitoviz_base.py
+++ b/mitoviz/cli/tests/test_mitoviz_base.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Created by Roberto Preste
+import os
+import unittest
+
+import cv2
+import numpy as np
+from click.testing import CliRunner
+
+from mitoviz.cli import mitoviz_base as cli
+from mitoviz.tests.constants import (
+    BASE_MITO_POLAR, BASE_MITO_POLAR_LEGEND, BASE_MITO_POLAR_SPLIT,
+    BASE_MITO_LINEAR, BASE_MITO_LINEAR_LEGEND, BASE_MITO_LINEAR_SPLIT,
+    BASE_MITO_PLOTLY, BASE_MITO_PLOTLY_LEGEND, BASE_MITO_PLOTLY_SPLIT,
+    BASE_MITO_PLOTLY_LINEAR, BASE_MITO_PLOTLY_LINEAR_LEGEND,
+    BASE_MITO_PLOTLY_LINEAR_SPLIT, OUTPUT_IMG, OUTPUT_HTML
+
+)
+
+
+class TestMitovizBase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+
+    def test_cli_base_help(self):
+        # Given/When
+        result = self.runner.invoke(cli.main, ["--help"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("Show this message and exit.", result.output)
+
+    def test_cli_base_polar(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR)
+
+        # When
+        result = self.runner.invoke(cli.main)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_cli_base_linear(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_LINEAR)
+
+        # When
+        result = self.runner.invoke(cli.main, ["--linear"])
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_cli_base_polar_plotly(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY
+        test_img = "base_mt.html"
+
+        # When
+        result = self.runner.invoke(cli.main, ["--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_base_linear_plotly(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LINEAR
+        test_img = "base_mt.html"
+
+        # When
+        result = self.runner.invoke(cli.main, ["--linear", "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_plot_polar_legend(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR_LEGEND)
+
+        # When
+        result = self.runner.invoke(cli.main, ["--legend"])
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_cli_base_linear_legend(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_LINEAR_LEGEND)
+
+        # When
+        result = self.runner.invoke(cli.main, ["--legend", "--linear"])
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_cli_base_polar_plotly_legend(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LEGEND
+        test_img = "base_mt.html"
+
+        # When
+        result = self.runner.invoke(cli.main, ["--legend", "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_base_linear_plotly_legend(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LINEAR_LEGEND
+        test_img = "base_mt.html"
+
+        # When
+        result = self.runner.invoke(cli.main,
+                                    ["--legend", "--linear", "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_base_output(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR)
+
+        # When
+        result = self.runner.invoke(cli.main, ["--output", OUTPUT_IMG])
+        result_img = cv2.imread(OUTPUT_IMG)
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(OUTPUT_IMG))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove(OUTPUT_IMG)
+
+    def test_cli_base_plotly_output(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY
+        test_img = OUTPUT_HTML
+
+        # When
+        result = self.runner.invoke(cli.main,
+                                    ["--interactive",
+                                     "--output", test_img])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_base_polar_split(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR_SPLIT)
+
+        # When
+        result = self.runner.invoke(cli.main, ["--split"])
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_cli_base_linear_split(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_LINEAR_SPLIT)
+
+        # When
+        result = self.runner.invoke(cli.main, ["--split", "--linear"])
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_cli_base_polar_plotly_split(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_SPLIT
+        test_img = "base_mt.html"
+
+        # When
+        result = self.runner.invoke(cli.main, ["--split", "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_base_linear_plotly_split(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LINEAR_SPLIT
+        test_img = "base_mt.html"
+
+        # When
+        result = self.runner.invoke(cli.main,
+                                    ["--split", "--linear", "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)

--- a/mitoviz/cli/tests/test_mitoviz_plot.py
+++ b/mitoviz/cli/tests/test_mitoviz_plot.py
@@ -8,7 +8,7 @@ import cv2
 import numpy as np
 from click.testing import CliRunner
 
-from mitoviz import cli
+from mitoviz.cli import mitoviz_plot as cli
 from mitoviz.tests.constants import (
     SAMPLE_VCF, SAMPLE_HF_VCF, SAMPLE_MULTI_VCF, SAMPLE_HF_CSV, SAMPLE_HF_TSV,
     SAMPLE_HF_TSV_COMM,
@@ -30,8 +30,6 @@ from mitoviz.tests.constants import (
     BASE_HF_IMG_LINEAR_LEGEND_DF, BASE_HF_IMG_LINEAR_SPLIT_DF,
     BASE_HF_IMG_PLOTLY_DF, BASE_HF_IMG_PLOTLY_LEGEND_DF,
     BASE_HF_IMG_PLOTLY_SPLIT_DF,
-    BASE_HF_IMG_PLOTLY_LINEAR_DF, BASE_HF_IMG_PLOTLY_LINEAR_LEGEND_DF,
-    BASE_HF_IMG_PLOTLY_LINEAR_SPLIT_DF,
     BASE_MULTI_IMG, BASE_MULTI_IMG_LABELS, BASE_MULTI_IMG_LEGEND,
     BASE_MULTI_IMG_SPLIT,
     BASE_MULTI_IMG_LINEAR, BASE_MULTI_IMG_LINEAR_LABELS,
@@ -50,7 +48,7 @@ class TestCliVcf(unittest.TestCase):
     def setUp(self) -> None:
         self.runner = CliRunner()
 
-    def test_cli_help(self):
+    def test_cli_plot_help(self):
         # Given/When
         result = self.runner.invoke(cli.main, ["--help"])
 
@@ -920,7 +918,6 @@ class TestCliCsv(unittest.TestCase):
 
     def test_cli_plot_linear_plotly_csv(self):
         # Given
-        base_img = BASE_HF_IMG_PLOTLY_LINEAR_DF
         test_img = "HG00420.html"
 
         # When
@@ -1020,7 +1017,6 @@ class TestCliCsv(unittest.TestCase):
 
     def test_cli_plot_linear_plotly_csv_legend(self):
         # Given
-        base_img = BASE_HF_IMG_PLOTLY_LINEAR_LEGEND_DF
         test_img = "HG00420.html"
 
         # When
@@ -1087,7 +1083,6 @@ class TestCliCsv(unittest.TestCase):
 
     def test_cli_plot_linear_plotly_csv_split(self):
         # Given
-        base_img = BASE_HF_IMG_PLOTLY_LINEAR_SPLIT_DF
         test_img = "HG00420.html"
 
         # When

--- a/mitoviz/mitoviz.py
+++ b/mitoviz/mitoviz.py
@@ -10,9 +10,53 @@ import pandas as pd
 from mitoviz.parsers import _DataFrameParser, _TabularParser, _VcfParser
 from mitoviz.plot import (
     _plot_variants_polar, _plot_variants_linear, _plotly_variants_polar,
-    _plotly_variants_linear
+    _plotly_variants_linear, _plot_mito_polar, _plot_mito_linear,
+    _plotly_mito_polar, _plotly_mito_linear
 )
 from mitoviz.utils import parse_path
+
+
+def plot_base(linear: bool = False,
+              save: bool = False,
+              output: Optional[str] = None,
+              legend: bool = False,
+              split: bool = False,
+              interactive: bool = False) -> None:
+    """ Plot the base mitochondrial representation.
+
+    Args:
+        linear: show a linear plot rather than a polar one [default: False]
+        save: if true, the final plot will be saved to a file [default: False]
+        output: path of the output file where the plot will be saved
+        legend: if true, add a legend for loci colors in the plot
+            [default: False]
+        split: if true, plot split H and L strands [default: True]
+        interactive: if true, create an interactive version of the plot
+            [default: False]
+    """
+    if linear:
+        if interactive:
+            plot_mito = _plotly_mito_linear
+        else:
+            plot_mito = _plot_mito_linear
+    else:
+        if interactive:
+            plot_mito = _plotly_mito_polar
+        else:
+            plot_mito = _plot_mito_polar
+
+    fig = plot_mito(legend, split)
+
+    if save:
+        dirname, name, ext = parse_path(output)
+        if name == "":
+            name = "base_mt"
+        if interactive:
+            fig.write_html(os.path.join(dirname, f"{name}.html"),
+                           auto_open=False)
+        else:
+            plt.savefig(os.path.join(dirname, f"{name}{ext}"))
+            plt.close()
 
 
 def plot_vcf(in_vcf: str,

--- a/mitoviz/tests/test_mitoviz.py
+++ b/mitoviz/tests/test_mitoviz.py
@@ -7,7 +7,7 @@ import unittest
 import cv2
 import numpy as np
 
-from mitoviz.mitoviz import plot_df, plot_table, plot_vcf
+from mitoviz.mitoviz import plot_base, plot_df, plot_table, plot_vcf
 from mitoviz.tests.constants import (
     SAMPLE_VCF, SAMPLE_HF_VCF, SAMPLE_MULTI_VCF, SAMPLE_CUSTOM_DF,
     SAMPLE_DF, SAMPLE_HF_DF, SAMPLE_MULTI_DF,
@@ -18,8 +18,219 @@ from mitoviz.tests.constants import (
     BASE_HF_IMG_DF, BASE_HF_IMG_LABELS_DF, BASE_HF_IMG_LEGEND_DF,
     BASE_MULTI_IMG, BASE_MULTI_IMG_LABELS, BASE_MULTI_IMG_LEGEND,
     BASE_MULTI_IMG_DF, BASE_MULTI_IMG_LABELS_DF, BASE_MULTI_IMG_LEGEND_DF,
-    OUTPUT_IMG, OUTPUT_HF_IMG, OUTPUT_MULTI_IMG
+    BASE_MITO_POLAR, BASE_MITO_POLAR_LEGEND, BASE_MITO_POLAR_SPLIT,
+    BASE_MITO_LINEAR, BASE_MITO_LINEAR_LEGEND, BASE_MITO_LINEAR_SPLIT,
+    BASE_MITO_PLOTLY, BASE_MITO_PLOTLY_LEGEND, BASE_MITO_PLOTLY_SPLIT,
+    BASE_MITO_PLOTLY_LINEAR, BASE_MITO_PLOTLY_LINEAR_LEGEND,
+    BASE_MITO_PLOTLY_LINEAR_SPLIT, OUTPUT_IMG, OUTPUT_HF_IMG, OUTPUT_MULTI_IMG,
+    OUTPUT_HTML
 )
+
+
+class TestModuleBase(unittest.TestCase):
+
+    def test_module_base_polar(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR)
+
+        # When
+        plot_base(save=True)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_module_base_linear(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_LINEAR)
+
+        # When
+        plot_base(linear=True, save=True)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_module_base_polar_plotly(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY
+        test_img = "base_mt.html"
+
+        # When
+        plot_base(interactive=True, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_module_base_linear_plotly(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LINEAR
+        test_img = "base_mt.html"
+
+        # When
+        plot_base(linear=True, interactive=True, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_module_plot_polar_legend(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR_LEGEND)
+
+        # When
+        plot_base(legend=True, save=True)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_module_base_linear_legend(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_LINEAR_LEGEND)
+
+        # When
+        plot_base(legend=True, linear=True, save=True)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_module_base_polar_plotly_legend(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LEGEND
+        test_img = "base_mt.html"
+
+        # When
+        plot_base(legend=True, interactive=True, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_module_base_linear_plotly_legend(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LINEAR_LEGEND
+        test_img = "base_mt.html"
+
+        # When
+        plot_base(legend=True, linear=True, interactive=True, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_module_base_output(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR)
+
+        # When
+        plot_base(output=OUTPUT_IMG, save=True)
+        result_img = cv2.imread(OUTPUT_IMG)
+
+        # Then
+        self.assertTrue(os.path.isfile(OUTPUT_IMG))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove(OUTPUT_IMG)
+
+    def test_module_base_plotly_output(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY
+        test_img = OUTPUT_HTML
+
+        # When
+        plot_base(interactive=True, output=test_img, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_module_base_polar_split(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_POLAR_SPLIT)
+
+        # When
+        plot_base(split=True, save=True)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_module_base_linear_split(self):
+        # Given
+        base_img = cv2.imread(BASE_MITO_LINEAR_SPLIT)
+
+        # When
+        plot_base(split=True, linear=True, save=True)
+        result_img = cv2.imread("base_mt.png")
+
+        # Then
+        self.assertTrue(os.path.isfile("base_mt.png"))
+        diff = cv2.subtract(base_img, result_img)
+        self.assertFalse(np.any(diff))
+        # Cleanup
+        os.remove("base_mt.png")
+
+    def test_module_base_polar_plotly_split(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_SPLIT
+        test_img = "base_mt.html"
+
+        # When
+        plot_base(split=True, interactive=True, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_module_base_linear_plotly_split(self):
+        # Given
+        base_img = BASE_MITO_PLOTLY_LINEAR_SPLIT
+        test_img = "base_mt.html"
+
+        # When
+        plot_base(split=True, linear=True, interactive=True, save=True)
+
+        # Then
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
 
 
 class TestModuleVcf(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(  # pragma: no cover
     description="Plot variants on the human mitochondrial genome.",
     entry_points={
         "console_scripts": [
-            "mitoviz=mitoviz.cli:main",
+            "mitoviz=mitoviz.cli.mitoviz_plot:main",
+            "mitoviz-base=mitoviz.cli.mitoviz_base:main"
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
Closes #68 

Mitoviz now provides the additional `mitoviz-base` CLI command to create base mitochondrial plots; its Python module equivalent is the `plot_base()` function. 