### PR TITLE
ENH: Show HF value in labels for interactive plots 

### DIFF
--- a/ci/create_suite.py
+++ b/ci/create_suite.py
@@ -22,9 +22,10 @@ from mitoviz.tests.constants import (
     BASE_IMG_SPLIT,
     BASE_IMG_LINEAR, BASE_IMG_LINEAR_LABELS, BASE_IMG_LINEAR_LEGEND,
     BASE_IMG_LINEAR_SPLIT, BASE_IMG_LINEAR_LABELS_HF,
-    BASE_IMG_PLOTLY, BASE_IMG_PLOTLY_LEGEND, BASE_IMG_PLOTLY_SPLIT,
-    BASE_IMG_PLOTLY_LINEAR, BASE_IMG_PLOTLY_LINEAR_LEGEND,
-    BASE_IMG_PLOTLY_LINEAR_SPLIT,
+    BASE_IMG_PLOTLY, BASE_IMG_PLOTLY_LABELS_HF, BASE_IMG_PLOTLY_LEGEND,
+    BASE_IMG_PLOTLY_SPLIT,
+    BASE_IMG_PLOTLY_LINEAR, BASE_IMG_PLOTLY_LINEAR_LABELS_HF,
+    BASE_IMG_PLOTLY_LINEAR_LEGEND, BASE_IMG_PLOTLY_LINEAR_SPLIT,
     BASE_IMG_DF, BASE_IMG_LABELS_DF, BASE_IMG_LEGEND_DF, BASE_IMG_SPLIT_DF,
     BASE_IMG_LINEAR_DF, BASE_IMG_LINEAR_LABELS_DF, BASE_IMG_LINEAR_LEGEND_DF,
     BASE_IMG_LINEAR_SPLIT_DF,
@@ -134,6 +135,8 @@ def create_sample_vcf_polar_plotly():
     plot_vcf(in_vcf=SAMPLE_VCF, save=True, interactive=True,
              output=BASE_IMG_PLOTLY)
     plot_vcf(in_vcf=SAMPLE_VCF, save=True, interactive=True,
+             output=BASE_IMG_PLOTLY_LABELS_HF, labels_hf=True)
+    plot_vcf(in_vcf=SAMPLE_VCF, save=True, interactive=True,
              output=BASE_IMG_PLOTLY_LEGEND, legend=True)
     plot_vcf(in_vcf=SAMPLE_VCF, save=True, interactive=True,
              output=BASE_IMG_PLOTLY_SPLIT, split=True)
@@ -143,6 +146,8 @@ def create_sample_vcf_linear_plotly():
     """ Create linear plots from sample.vcf with plotly. """
     plot_vcf(in_vcf=SAMPLE_VCF, linear=True, save=True, interactive=True,
              output=BASE_IMG_PLOTLY_LINEAR)
+    plot_vcf(in_vcf=SAMPLE_VCF, linear=True, save=True, interactive=True,
+             output=BASE_IMG_PLOTLY_LINEAR_LABELS_HF, labels_hf=True)
     plot_vcf(in_vcf=SAMPLE_VCF, linear=True, save=True, interactive=True,
              output=BASE_IMG_PLOTLY_LINEAR_LEGEND, legend=True)
     plot_vcf(in_vcf=SAMPLE_VCF, linear=True, save=True, interactive=True,

--- a/mitoviz/cli/tests/test_mitoviz_plot.py
+++ b/mitoviz/cli/tests/test_mitoviz_plot.py
@@ -15,9 +15,10 @@ from mitoviz.tests.constants import (
     BASE_IMG, BASE_IMG_LABELS, BASE_IMG_LEGEND, BASE_IMG_SPLIT,
     BASE_IMG_LINEAR, BASE_IMG_LINEAR_LABELS, BASE_IMG_LINEAR_LEGEND,
     BASE_IMG_LINEAR_SPLIT, BASE_IMG_LABELS_HF, BASE_IMG_LINEAR_LABELS_HF,
-    BASE_IMG_PLOTLY, BASE_IMG_PLOTLY_LEGEND, BASE_IMG_PLOTLY_SPLIT,
-    BASE_IMG_PLOTLY_LINEAR, BASE_IMG_PLOTLY_LINEAR_LEGEND,
-    BASE_IMG_PLOTLY_LINEAR_SPLIT,
+    BASE_IMG_PLOTLY, BASE_IMG_PLOTLY_LABELS_HF, BASE_IMG_PLOTLY_LEGEND,
+    BASE_IMG_PLOTLY_SPLIT,
+    BASE_IMG_PLOTLY_LINEAR, BASE_IMG_PLOTLY_LINEAR_LABELS_HF,
+    BASE_IMG_PLOTLY_LINEAR_LEGEND, BASE_IMG_PLOTLY_LINEAR_SPLIT,
     BASE_HF_IMG, BASE_HF_IMG_LABELS, BASE_HF_IMG_LEGEND, BASE_HF_IMG_SPLIT,
     BASE_HF_IMG_LINEAR, BASE_HF_IMG_LINEAR_LABELS, BASE_HF_IMG_LINEAR_LEGEND,
     BASE_HF_IMG_LINEAR_SPLIT,
@@ -222,6 +223,23 @@ class TestCliVcf(unittest.TestCase):
         # Cleanup
         os.remove("MITOVIZ001.png")
 
+    def test_cli_plot_polar_plotly_labels_hf(self):
+        # Given
+        base_img = BASE_IMG_PLOTLY_LABELS_HF
+        test_img = "MITOVIZ001.html"
+
+        # When
+        result = self.runner.invoke(cli.main,
+                                    [SAMPLE_VCF, "--labels-hf",
+                                     "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
     def test_cli_plot_polar_plotly_legend(self):
         # Given
         base_img = BASE_IMG_PLOTLY_LEGEND
@@ -230,6 +248,23 @@ class TestCliVcf(unittest.TestCase):
         # When
         result = self.runner.invoke(cli.main,
                                     [SAMPLE_VCF, "--legend", "--interactive"])
+
+        # Then
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isfile(test_img))
+        self.assertEqual(os.path.getsize(base_img), os.path.getsize(test_img))
+        # Cleanup
+        os.remove(test_img)
+
+    def test_cli_plot_linear_plotly_labels_hf(self):
+        # Given
+        base_img = BASE_IMG_PLOTLY_LINEAR_LABELS_HF
+        test_img = "MITOVIZ001.html"
+
+        # When
+        result = self.runner.invoke(cli.main,
+                                    [SAMPLE_VCF, "--labels-hf", "--linear",
+                                     "--interactive"])
 
         # Then
         self.assertEqual(0, result.exit_code)

--- a/mitoviz/plot.py
+++ b/mitoviz/plot.py
@@ -396,7 +396,10 @@ def _plotly_variants_polar(sample: str,
 
     radii = [el.polar_y for el in variants]
     theta = [el.polar_x_p for el in variants]
-    meta = [el.label for el in variants]
+    if labels_hf:
+        meta = [el.label_hf_plotly for el in variants]
+    else:
+        meta = [el.label for el in variants]
 
     var_trace = go.Scatterpolar(r=radii, theta=theta, mode="markers",
                                 marker=dict(color="black"), meta=meta,
@@ -468,7 +471,10 @@ def _plotly_variants_linear(sample: str,
 
     xs = [variant.linear_x for variant in variants]
     ys = [variant.linear_y for variant in variants]
-    meta = [el.label for el in variants]
+    if labels_hf:
+        meta = [el.label_hf_plotly for el in variants]
+    else:
+        meta = [el.label for el in variants]
 
     var_trace = go.Scatter(x=xs, y=ys, mode="markers",
                            marker=dict(color="black"), meta=meta,

--- a/mitoviz/tests/constants.py
+++ b/mitoviz/tests/constants.py
@@ -52,10 +52,14 @@ BASE_IMG_LINEAR_LEGEND = os.path.join(IMGDIR, "sample_linear_legend.png")
 BASE_IMG_LINEAR_SPLIT = os.path.join(IMGDIR, "sample_linear_split.png")
 
 BASE_IMG_PLOTLY = os.path.join(IMGDIR, "sample_plotly.html")
+BASE_IMG_PLOTLY_LABELS_HF = os.path.join(
+    IMGDIR, "sample_plotly_labels_hf.html")
 BASE_IMG_PLOTLY_LEGEND = os.path.join(IMGDIR, "sample_plotly_legend.html")
 BASE_IMG_PLOTLY_SPLIT = os.path.join(IMGDIR, "sample_plotly_split.html")
 
 BASE_IMG_PLOTLY_LINEAR = os.path.join(IMGDIR, "sample_plotly_linear.html")
+BASE_IMG_PLOTLY_LINEAR_LABELS_HF = os.path.join(
+    IMGDIR, "sample_plotly_linear_labels_hf.html")
 BASE_IMG_PLOTLY_LINEAR_LEGEND = os.path.join(
     IMGDIR, "sample_plotly_linear_legend.html")
 BASE_IMG_PLOTLY_LINEAR_SPLIT = os.path.join(

--- a/mitoviz/tests/test_variant.py
+++ b/mitoviz/tests/test_variant.py
@@ -83,6 +83,11 @@ class TestVariant(unittest.TestCase):
         self.assertEqual("3308C>A\nHF: 0.3", self.variant.label_hf)
         self.assertEqual("3308C>A\nHF: 0.3", self.variant_raw.label_hf)
 
+    def test_label_hf_plotly(self):
+        self.assertEqual("3308C>A<br>HF: 0.3", self.variant.label_hf_plotly)
+        self.assertEqual("3308C>A<br>HF: 0.3",
+                         self.variant_raw.label_hf_plotly)
+
     def test_polar_x(self):
         self.assertEqual(1.2557981773190898, self.variant.polar_x)
 

--- a/mitoviz/variant.py
+++ b/mitoviz/variant.py
@@ -76,6 +76,13 @@ class _Variant:
         return label
 
     @property
+    def label_hf_plotly(self) -> str:
+        """ Create the variant label with additional HF value (used in
+        interactive plots)."""
+        label = self.label + f"<br>HF: {self.hf}"
+        return label
+
+    @property
     def linear_x(self) -> int:
         """ The x position of the variant on the linear mt genome plot. """
         return self.position


### PR DESCRIPTION
Closes #75 and closes #76 

The `--labels-hf` and `labels_hf=True` options in the CLI and Python module respectively now allow to include the HF value of variants in labels shown in both static and interactive plots. 